### PR TITLE
docs(seed): Fix a few minor spelling mistakes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@ New features are welcome! Either as requests or proposals.
 6. When creating commits, please conform to [the angular commit message style](https://docs.google.com/document/d/1rk04jEuGfk9kYzfqCuOlPTSJw3hEDZJTBN5E5f1SALo/edit).
    Namely in the form `<type>(<scope>): <subject>\n\n[body]`
    * Type: feat, fix, docs, style, refactor, test, chore.
-   * Scope can the the file or group of files (not a strict right or wrong)
-   * Subject and body: present tense (~changed~*change*, ~added~*add*) and include motivation and contrasts with previous behavior
+   * Scope can be the file or group of files (not a strict right or wrong)
+   * Subject and body: present tense (~changed~*change*, ~added~*add*) and include motivation and contrasts with previous behaviour
   
 
 Don't get discouraged! We estimate that the response time from the
@@ -35,7 +35,7 @@ Please report a bug report on our [issues page](https://github.com/stryker-mutat
 1. Label the issue as bug
 2. Explain what the bug is in clear English
 3. Include reproduction steps
-   This can be an example project, code snippit, etc
+   This can be an example project, code snippet, etc
 4. Include the expected behaviour.
 5. Include actual behaviour.
 6. Add more details if required (i.e. which browser, which test runner, which versions, etc)

--- a/src/MyReporter.ts
+++ b/src/MyReporter.ts
@@ -7,9 +7,9 @@ export default class MyReporter implements Reporter {
   }
 
   /**
-     * Called when a source file was loaded
-     * @param file The immutable source file
-     */
+   * Called when a source file was loaded
+   * @param file The immutable source file
+   */
   onSourceFileRead(file: SourceFile): void {
 
   }
@@ -39,9 +39,9 @@ export default class MyReporter implements Reporter {
   }
 
   /**
-   * Called when stryker wants to quite
+   * Called when stryker wants to quit
    * Gives a reporter the ability to finish up any async tasks
-   * Stryker will not close untill the promise is either resolved or rejected.
+   * Stryker will not close until the promise is either resolved or rejected.
    * @return a promise which will resolve when the reporter is done reporting
    */
   wrapUp(): void | Promise<void> {

--- a/src/MyTestRunner.ts
+++ b/src/MyTestRunner.ts
@@ -5,7 +5,7 @@ import { EventEmitter } from 'events';
  * Represents a TestRunner which can execute tests, resulting in a RunResult.
  *
  * A test runner should:
- *  - Report per a `testResult` per test. See `TestResult` interfact to know what is expected.
+ *  - Report a `testResult` per test. See `TestResult` interfact to know what is expected.
  *  - Emit `'test_done'` event with a TestResult as argument every time a test is executed (for reporting purposes)
  *  - Report on code coverage after the initial test run (maybe, see below)
  *
@@ -24,10 +24,10 @@ import { EventEmitter } from 'events';
  * 3. If `coverageStrategy: 'perTest'`: Coverage should be collected per test.
  *
  * For 2 and 3, Stryker will instrument the code with the istanbul code coverage engine during initial run.
- * In case of 3, Stryker will also inject beforeEach and afterEach hooks (specific to each test framework) in distinct between specific tests.
+ * In case of 3, Stryker will also inject `beforeEach` and `afterEach` hooks (specific to each test framework) in distinct between specific tests.
  *
  * At the end of the test run, the code coverage report is ready in a global variable called `__coverage__`. Node based test runners
- * which run there tests in the same process as the test runner is spawned in actually don't have to do any work, Stryker will be able
+ * which run their tests in the same process as the test runner is spawned in actually don't have to do any work, Stryker will be able
  * to pick up the report globally. However, if running in worker processes or a browser, it is the test runner's responsibility to
  * report the `__coverage__` at the end of the test run.
  *
@@ -56,8 +56,8 @@ export default class MyTestRunner extends EventEmitter implements TestRunner {
   run(options: RunOptions): Promise<RunResult> {
     const oneTestResult: TestResult = {
       /**
-      * The full human readable name of the test
-      */
+       * The full human readable name of the test
+       */
       name: '',
       /**
        * The state of the test
@@ -76,8 +76,8 @@ export default class MyTestRunner extends EventEmitter implements TestRunner {
 
     return Promise.resolve({
       /**
-          * The individual test results.
-          */
+       * The individual test results.
+       */
       tests: [oneTestResult],
       /**
        * If `state` is `error`, this collection should contain the error messages
@@ -88,8 +88,8 @@ export default class MyTestRunner extends EventEmitter implements TestRunner {
        */
       state: RunState.Complete,
       /**
-     * Optional: the code coverage result of the run.
-     */
+       * Optional: the code coverage result of the run.
+       */
       // coverage?: CoverageCollection | CoverageCollectionPerTest;
 
     });


### PR DESCRIPTION
While using the plugin seed I noticed a few inconsistencies in spelling (American vs. English) as well as some mistakes.